### PR TITLE
FIX Leave property form on fixed position during scroll

### DIFF
--- a/frontend/etcdbrowser.js
+++ b/frontend/etcdbrowser.js
@@ -226,4 +226,10 @@ app.controller('NodeCtrl', ['$scope','$http','$cookies', function($scope,$http,$
 
 app.run(function(editableOptions) {
   editableOptions.theme = 'bs3';
+}).directive('propertyForm', function () {
+  return {
+    link: function () {
+      $(".property-form").affix({offset: {top: $(".top-buffer").position().top} }).width($('.tree').width());
+    }
+  }
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -96,7 +96,7 @@
         </div>
       </div>
       <div class="col-md-6">
-        <div class="prop-block" ng-include="'prop-block'" ng-if="activeNode"></div>
+        <div class="prop-block property-form" ng-include="'prop-block'" ng-if="activeNode" property-form></div>
       </div>
     </div>
 		<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -104,8 +104,11 @@
 }
 
 .prop-block {
-  height: 100%;
   overflow: auto;
+}
+
+.property-form {
+  top: 10px;
 }
 
 .col-md-6 .col-md-6 {


### PR DESCRIPTION
It is very inconvenient to chose some setting key and scroll up to find its value. Values block will stay on its position during scroll with this small fix.